### PR TITLE
chore: update split action in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ steps:
       keyPassword: ${{ secrets.ANDROID_KEY_PASSWORD }}
       buildToolsVersion: 33.0.0
 
-  - uses: jungwinter/split@v1
+  - uses: jungwinter/split@v2
     id: signed_files
     with:
       msg: ${{ steps.sign_app.outputs.signedFiles }}


### PR DESCRIPTION
Update split action version in example. 

split@v1 has typos “separator”, so this example did not work.
https://github.com/JungWinter/split/pull/6