### PR TITLE
chore: bump gradle to `7.6.1`

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
I'm very sorry about my PR (#15), I accidentally mistook `gradlew --warning-mode all` for `gradlew build` because I was using the arrow key out of habit without paying close attention to the command, I'll make sure to double-check next time!